### PR TITLE
Lw redo batching

### DIFF
--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -50,7 +50,6 @@ router.post(
       };
       const webhookHandler = webhookHandlerMap[type] || unhandledWebhook;
       await webhookHandler(req.body, io);
-      console.log('finished!');
       res.json({ status: 'ok' });
     } catch (err) {
       console.log(err);

--- a/server/webhookHandlers/handleTransferWebhook.js
+++ b/server/webhookHandlers/handleTransferWebhook.js
@@ -50,7 +50,7 @@ const transfersHandler = async (requestBody, io) => {
         const appStatus = await retrieveAppStatus();
         let afterId = appStatus[0].number_of_events;
         let hasEventsToFetch = true;
-        const batchSize = 25; // 25 is the maximum number of events returned
+        const batchSize = 2; // 25 is the maximum number of events returned
         let allNewPlaidEvents = [];
         while (hasEventsToFetch) {
           const sycnRequest = {
@@ -58,7 +58,7 @@ const transfersHandler = async (requestBody, io) => {
             count: batchSize,
           };
           const syncResponse = await plaid.transferEventSync(sycnRequest);
-          allNewPlaidEvents = await allNewPlaidEvents.concat(
+          allNewPlaidEvents = allNewPlaidEvents.concat(
             syncResponse.data.transfer_events
           );
           if (syncResponse.data.transfer_events.length === batchSize) {

--- a/server/webhookHandlers/handleTransferWebhook.js
+++ b/server/webhookHandlers/handleTransferWebhook.js
@@ -50,7 +50,7 @@ const transfersHandler = async (requestBody, io) => {
         const appStatus = await retrieveAppStatus();
         let afterId = appStatus[0].number_of_events;
         let hasEventsToFetch = true;
-        const batchSize = 2; // 25 is the maximum number of events returned
+        const batchSize = 25; // 25 is the maximum number of events returned
         let allNewPlaidEvents = [];
         while (hasEventsToFetch) {
           const sycnRequest = {
@@ -62,7 +62,7 @@ const transfersHandler = async (requestBody, io) => {
             syncResponse.data.transfer_events
           );
           if (allNewPlaidEvents.length === batchSize) {
-            afterId += allNewPlaidEvents.length;
+            afterId += syncResponse.data.transfer_events.length();
           } else {
             hasEventsToFetch = false;
           }

--- a/server/webhookHandlers/handleTransferWebhook.js
+++ b/server/webhookHandlers/handleTransferWebhook.js
@@ -51,14 +51,14 @@ const transfersHandler = async (requestBody, io) => {
         let afterId = appStatus[0].number_of_events;
         let hasEventsToFetch = true;
         const batchSize = 2; // 25 is the maximum number of events returned
-        let allNewPlaidEvents;
+        let allNewPlaidEvents = [];
         while (hasEventsToFetch) {
           const sycnRequest = {
             after_id: afterId,
             count: batchSize,
           };
           const syncResponse = await plaid.transferEventSync(sycnRequest);
-          allNewPlaidEvents = allNewPlaidEvents.concat(
+          allNewPlaidEvents = await allNewPlaidEvents.concat(
             syncResponse.data.transfer_events
           );
           if (allNewPlaidEvents.length === batchSize) {

--- a/server/webhookHandlers/handleTransferWebhook.js
+++ b/server/webhookHandlers/handleTransferWebhook.js
@@ -13,7 +13,6 @@ const {
   updateAppStatus,
 } = require('../db/queries');
 const plaid = require('../plaid');
-const { all } = require('../routes/users');
 
 /**
  * Handles all Transfers webhook events.

--- a/server/webhookHandlers/handleTransferWebhook.js
+++ b/server/webhookHandlers/handleTransferWebhook.js
@@ -50,7 +50,7 @@ const transfersHandler = async (requestBody, io) => {
         const appStatus = await retrieveAppStatus();
         let afterId = appStatus[0].number_of_events;
         let hasEventsToFetch = true;
-        const batchSize = 2; // 25 is the maximum number of events returned
+        const batchSize = 25; // 25 is the maximum number of events returned
         let allNewPlaidEvents = [];
         while (hasEventsToFetch) {
           const sycnRequest = {

--- a/server/webhookHandlers/handleTransferWebhook.js
+++ b/server/webhookHandlers/handleTransferWebhook.js
@@ -13,6 +13,7 @@ const {
   updateAppStatus,
 } = require('../db/queries');
 const plaid = require('../plaid');
+const { all } = require('../routes/users');
 
 /**
  * Handles all Transfers webhook events.
@@ -61,8 +62,8 @@ const transfersHandler = async (requestBody, io) => {
           allNewPlaidEvents = await allNewPlaidEvents.concat(
             syncResponse.data.transfer_events
           );
-          if (allNewPlaidEvents.length === batchSize) {
-            afterId += syncResponse.data.transfer_events.length();
+          if (syncResponse.data.transfer_events.length === batchSize) {
+            afterId += syncResponse.data.transfer_events.length;
           } else {
             hasEventsToFetch = false;
           }
@@ -115,8 +116,8 @@ const transfersHandler = async (requestBody, io) => {
 
         const oldAccountBalance = appStatus[0].app_account_balance;
         const newAccountBalance = oldAccountBalance + newSweepAmountToAdd;
-        const newNumberOfEvents = (appStatus[0].number_of_events +=
-          allNewPlaidEvents.length);
+        const newNumberOfEvents =
+          appStatus[0].number_of_events + allNewPlaidEvents.length;
         await updateAppStatus(newAccountBalance, newNumberOfEvents);
 
         const newStatus = await retrieveAppStatus();


### PR DESCRIPTION
Changes the way the batching of events is done: 
This PR changes the way the transfer/event/sync is called after webhooks are received. Instead of gathering the first 25 and performing saves and transfer/gets on each event, and then gathering the next 25 and doing the same, it instead gathers all events up front before doing anything to each event.